### PR TITLE
Bugfixes: error wrapping and extra validators application

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ if lint {
 
 let package = Package(
     name: "SwiftApiDsl",
-    platforms: [.iOS(.v13), .macOS(.v10_15)],
+    platforms: [.iOS(.v13), .macOS(.v12)],
     products: [
         .library(
             name: "SwiftApiDsl",

--- a/Sources/SwiftApiDsl/RequestError.swift
+++ b/Sources/SwiftApiDsl/RequestError.swift
@@ -11,6 +11,8 @@ public struct RequestError: Error {
         case validationError(data: Data, response: HTTPURLResponse, error: Error)
         /// The URLResponse of the request is not an HTTPURLResponse 🤷‍♂️
         case notHttpResponse(URLResponse?)
+        /// The response passed validation, but its body failed to decode as the expected type
+        case decode(data: Data, response: HTTPURLResponse, error: Error, expectedType: Any.Type)
         /// Terrible inconsistency, should never happen
         case unknown(Error?)
         /// The client was deallocated during a download
@@ -29,6 +31,9 @@ public struct RequestError: Error {
             case .notHttpResponse(let urlResponse):
                 return "The URLResponse \(urlResponse?.debugDescription ?? "(nil)") of the request is not an "
                 + "HTTPURLResponse 🤷‍♂️"
+            case .decode(data: _, response: let response, error: let error, expectedType: let expectedType):
+                return "The response \(response.debugDescription) passed validation, but its body failed to decode as "
+                + "the expected type \(expectedType). Error: \(error.localizedDescription)"
             case .unknown(let error):
                 return "Terrible inconsistency, should never happen: \(error?.localizedDescription ?? "")"
             case .clientDeallocated:


### PR DESCRIPTION
- increase macOS min version to v12 to be able to lint using `Packages.swift` flag
- extra validators were ignored when default ones were
- transport errors were not wrapped
- decode errors were not wrapped, created new enum case