### PR TITLE
Add core tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ let profile: Profile = try await client.perform(.get("user/profile")) // `Profil
 try await client.perform(.post("user/profile"), body: newProfile) // `newProfile`'s type must conform to `Encodable`
 
 // Fetch both parsed JSON body and `HTTPURLResponse`
-let (body, response): (Profile, HTTPURLResponse) = try await client.perform(.get("user/profile"))
+let (body, response): (Profile, HTTPURLResponse) = try await client.fetchResponse(.get("user/profile"))
 
 // Fetch both `Data` body and `HTTPURLResponse`
-let (dataBody, response) = try await client.perform(.get("user/profile"))
+let (dataBody, response) = try await client.fetchResponse(.get("user/profile"))
 
 // Add multipart form data
 let formData = MultipartFormDataModifier
@@ -50,7 +50,7 @@ try await client.download(get("user/bills/8"), destination: localDestinationUrl)
 You can customize your request easily with extra arguments to `.get()`, `.post()` etc... or with `with()` modifiers
  (see below).
 
-A number of options are available through `perform()` and `download()` functions:
+A number of options are available through `perform()`, `fetchResponse()` and `download()` functions:
 -  provide custom `JSONEncoder` and `JSONDecoder`, note that you can do this for all requests by passing them to the 
 `ApiClient` constructor.
 - if you provided request modifiers in the constructor, ignore them for a specific request 
@@ -191,7 +191,7 @@ let urlRequest: URLRequest = request.toUrlRequest(baseUrl: baseUrl)
 
 ## Perform on `URLRequest` directly
 
-The same functions `perform()` and `download()` are available that take an `URLRequest` as first parameter
+The same functions `perform()`, `fetchResponse()` and `download()` are available that take an `URLRequest` as first parameter
 instead of a `Request`.
 
 ```swift
@@ -218,6 +218,8 @@ public enum ErrorWrapper: Error {
     case validationError(data: Data, response: HTTPURLResponse, error: Error)
     /// The URLResponse of the request is not an HTTPURLResponse 🤷‍♂️
     case notHttpResponse(URLResponse?)
+    /// The response passed validation, but its body failed to decode as the expected type
+    case decode(data: Data, response: HTTPURLResponse, error: Error, expectedType: Any.Type)
     /// Terrible inconsistency, should never happen
     case unknown(Error?)
     /// The client was deallocated during a download

--- a/Sources/SwiftApiDsl/ApiClient.swift
+++ b/Sources/SwiftApiDsl/ApiClient.swift
@@ -133,7 +133,7 @@ extension ApiClient {
 public extension ApiClient {
 
     @discardableResult
-    func perform<RequestBody: Encodable>(
+    func fetchResponse<RequestBody: Encodable>(
         _ urlRequest: URLRequest,
         body: RequestBody = nil as String?,
         jsonEncoder: JSONEncoder? = nil,
@@ -159,7 +159,7 @@ public extension ApiClient {
     }
 
     @discardableResult
-    func perform<RequestBody: Encodable, ResponseBody: Decodable>(
+    func fetchResponse<RequestBody: Encodable, ResponseBody: Decodable>(
         _ urlRequest: URLRequest,
         body: RequestBody = nil as String?,
         jsonEncoder: JSONEncoder? = nil,
@@ -169,12 +169,12 @@ public extension ApiClient {
         extraValidators: [ResponseValidator] = [],
         responseBodyType: ResponseBody.Type? = nil
     ) async throws -> (body: ResponseBody, response: HTTPURLResponse) {
-        let (data, response) = try await perform(urlRequest,
-                                                 body: body,
-                                                 jsonEncoder: jsonEncoder,
-                                                 ignoreDefaultModifiers: ignoreDefaultModifiers,
-                                                 ignoreDefaultValidators: ignoreDefaultValidators,
-                                                 extraValidators: extraValidators)
+        let (data, response) = try await fetchResponse(urlRequest,
+                                                       body: body,
+                                                       jsonEncoder: jsonEncoder,
+                                                       ignoreDefaultModifiers: ignoreDefaultModifiers,
+                                                       ignoreDefaultValidators: ignoreDefaultValidators,
+                                                       extraValidators: extraValidators)
         let body: ResponseBody = try decode(request: urlRequest,
                                             data: data,
                                             response: response,
@@ -193,14 +193,14 @@ public extension ApiClient {
         extraValidators: [ResponseValidator] = [],
         responseBodyType: ResponseBody.Type? = nil
     ) async throws -> ResponseBody {
-        try await perform(urlRequest,
-                          body: body,
-                          jsonEncoder: jsonEncoder,
-                          jsonDecoder: jsonDecoder,
-                          ignoreDefaultModifiers: ignoreDefaultModifiers,
-                          ignoreDefaultValidators: ignoreDefaultValidators,
-                          extraValidators: extraValidators,
-                          responseBodyType: responseBodyType).body
+        try await fetchResponse(urlRequest,
+                                body: body,
+                                jsonEncoder: jsonEncoder,
+                                jsonDecoder: jsonDecoder,
+                                ignoreDefaultModifiers: ignoreDefaultModifiers,
+                                ignoreDefaultValidators: ignoreDefaultValidators,
+                                extraValidators: extraValidators,
+                                responseBodyType: responseBodyType).body
     }
 
     @discardableResult
@@ -250,7 +250,7 @@ public extension ApiClient {
 public extension ApiClient {
 
     @discardableResult
-    func perform<RequestBody: Encodable>(
+    func fetchResponse<RequestBody: Encodable>(
         _ request: Request,
         body: RequestBody = nil as String?,
         jsonEncoder: JSONEncoder? = nil,
@@ -258,16 +258,16 @@ public extension ApiClient {
         ignoreDefaultValidators: Bool = false,
         extraValidators: [ResponseValidator] = []
     ) async throws -> (data: Data, response: HTTPURLResponse) {
-        try await perform(request.toUrlRequest(baseUrl: baseUrl),
-                          body: body,
-                          jsonEncoder: jsonEncoder,
-                          ignoreDefaultModifiers: ignoreDefaultModifiers,
-                          ignoreDefaultValidators: ignoreDefaultValidators,
-                          extraValidators: extraValidators)
+        try await fetchResponse(request.toUrlRequest(baseUrl: baseUrl),
+                                body: body,
+                                jsonEncoder: jsonEncoder,
+                                ignoreDefaultModifiers: ignoreDefaultModifiers,
+                                ignoreDefaultValidators: ignoreDefaultValidators,
+                                extraValidators: extraValidators)
     }
 
     @discardableResult
-    func perform<RequestBody: Encodable, ResponseBody: Decodable>(
+    func fetchResponse<RequestBody: Encodable, ResponseBody: Decodable>(
         _ request: Request,
         body: RequestBody = nil as String?,
         jsonEncoder: JSONEncoder? = nil,
@@ -277,13 +277,13 @@ public extension ApiClient {
         extraValidators: [ResponseValidator] = [],
         responseBodyType: ResponseBody.Type? = nil
     ) async throws -> (body: ResponseBody, response: HTTPURLResponse) {
-        try await perform(request.toUrlRequest(baseUrl: baseUrl),
-                          body: body,
-                          jsonEncoder: jsonEncoder,
-                          jsonDecoder: jsonDecoder,
-                          ignoreDefaultModifiers: ignoreDefaultModifiers,
-                          ignoreDefaultValidators: ignoreDefaultValidators,
-                          extraValidators: extraValidators)
+        try await fetchResponse(request.toUrlRequest(baseUrl: baseUrl),
+                                body: body,
+                                jsonEncoder: jsonEncoder,
+                                jsonDecoder: jsonDecoder,
+                                ignoreDefaultModifiers: ignoreDefaultModifiers,
+                                ignoreDefaultValidators: ignoreDefaultValidators,
+                                extraValidators: extraValidators)
     }
 
     @discardableResult

--- a/Sources/SwiftApiDsl/ApiClient.swift
+++ b/Sources/SwiftApiDsl/ApiClient.swift
@@ -24,7 +24,7 @@ public class ApiClient {
     }
 }
 
-private extension ApiClient {
+extension ApiClient {
     func modify(request: inout URLRequest,
                 extraModifiers: [RequestModifier],
                 ignoreDefaultModifiers: Bool) async throws {

--- a/Sources/SwiftApiDsl/ApiClient.swift
+++ b/Sources/SwiftApiDsl/ApiClient.swift
@@ -28,12 +28,8 @@ extension ApiClient {
     func modify(request: inout URLRequest,
                 extraModifiers: [RequestModifier],
                 ignoreDefaultModifiers: Bool) async throws {
-        let modifiers: [RequestModifier]
-        if ignoreDefaultModifiers {
-            modifiers = extraModifiers
-        } else {
-            modifiers = self.modifiers + extraModifiers
-        }
+        var modifiers = ignoreDefaultModifiers ? [] : self.modifiers
+        modifiers += extraModifiers
         for modifier in modifiers {
             do {
                 try await modifier.modify(&request)

--- a/Sources/SwiftApiDsl/Validators/BlockValidator.swift
+++ b/Sources/SwiftApiDsl/Validators/BlockValidator.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct BlockValidator: ResponseValidator {
+
+    private let block: (Data, HTTPURLResponse) throws -> Void
+
+    init(block: @escaping (Data, HTTPURLResponse) throws -> Void) {
+        self.block = block
+    }
+
+    func validate(data: Data, response: HTTPURLResponse) throws {
+        try block(data, response)
+    }
+}

--- a/Tests/SwiftApiDslTests/ApiClientTests.swift
+++ b/Tests/SwiftApiDslTests/ApiClientTests.swift
@@ -100,4 +100,106 @@ final class ApiClientTests: XCTestCase {
             }
         }
     }
+
+    @MainActor
+    func test_validate_applies_default_validators_when_ignoreDefaultValidators_false() async throws {
+        let request = Request()
+        let urlRequest = try await request.toUrlRequest(baseUrl: url)
+        let validator = BlockValidator { _, _ in
+            throw TestError()
+        }
+        let client = ApiClient(baseUrl: url, validators: [validator])
+        XCTAssertThrowsError(
+            try client.validate(request: urlRequest,
+                                data: Data(),
+                                response: HTTPURLResponse(),
+                                ignoreDefaultValidators: false,
+                                extraValidators: [])
+        ) { error in
+            guard let requestError = error as? RequestError else {
+                XCTFail("Thrown error should be a RequestError")
+                return
+            }
+            if case let .validationError(data: _, response: _, error: error) = requestError.error {
+                XCTAssertEqual(error as? TestError, TestError(),
+                               "Expected error to be equal to the one thrown by the validator")
+            } else {
+                XCTFail("Expected wrapped error to be case validationError")
+            }
+        }
+    }
+
+    @MainActor
+    func test_validate_doesnt_apply_default_validators_when_ignoreDefaultValidators_false() async throws {
+        let request = Request()
+        let urlRequest = try await request.toUrlRequest(baseUrl: url)
+        let validator = BlockValidator { _, _ in
+            throw TestError()
+        }
+        let client = ApiClient(baseUrl: url, validators: [validator])
+        XCTAssertNoThrow(
+            try client.validate(request: urlRequest,
+                                data: Data(),
+                                response: HTTPURLResponse(),
+                                ignoreDefaultValidators: true,
+                                extraValidators: []),
+            "Expect validate to not throw with ignoreDefaultValidators true"
+        )
+    }
+
+    @MainActor
+    func test_validate_applies_extra_validators_when_ignoreDefaultValidators_false() async throws {
+        let request = Request()
+        let urlRequest = try await request.toUrlRequest(baseUrl: url)
+        let validator = BlockValidator { _, _ in
+            throw TestError()
+        }
+        let client = ApiClient(baseUrl: url)
+        XCTAssertThrowsError(
+            try client.validate(request: urlRequest,
+                                data: Data(),
+                                response: HTTPURLResponse(),
+                                ignoreDefaultValidators: false,
+                                extraValidators: [validator])
+        ) { error in
+            guard let requestError = error as? RequestError else {
+                XCTFail("Thrown error should be a RequestError")
+                return
+            }
+            if case let .validationError(data: _, response: _, error: error) = requestError.error {
+                XCTAssertEqual(error as? TestError, TestError(),
+                               "Expected error to be equal to the one thrown by the validator")
+            } else {
+                XCTFail("Expected wrapped error to be case validationError")
+            }
+        }
+    }
+
+    @MainActor
+    func test_validate_applies_extra_validators_when_ignoreDefaultValidators_true() async throws {
+        let request = Request()
+        let urlRequest = try await request.toUrlRequest(baseUrl: url)
+        let validator = BlockValidator { _, _ in
+            throw TestError()
+        }
+        let client = ApiClient(baseUrl: url)
+        XCTAssertThrowsError(
+            try client.validate(request: urlRequest,
+                                data: Data(),
+                                response: HTTPURLResponse(),
+                                ignoreDefaultValidators: true,
+                                extraValidators: [validator])
+        ) { error in
+            guard let requestError = error as? RequestError else {
+                XCTFail("Thrown error should be a RequestError")
+                return
+            }
+            if case let .validationError(data: _, response: _, error: error) = requestError.error {
+                XCTAssertEqual(error as? TestError, TestError(),
+                               "Expected error to be equal to the one thrown by the validator")
+            } else {
+                XCTFail("Expected wrapped error to be case validationError")
+            }
+        }
+    }
 }

--- a/Tests/SwiftApiDslTests/ApiClientTests.swift
+++ b/Tests/SwiftApiDslTests/ApiClientTests.swift
@@ -2,6 +2,102 @@ import XCTest
 @testable import SwiftApiDsl
 
 final class ApiClientTests: XCTestCase {
-    func testExample() throws {
+    let url = URL(string: "https://google.com")!
+
+    @MainActor
+    func test_modify_applies_default_modifiers_when_ignoreDefaultModifiers_false() async throws {
+        let httpMethod = "EXPECTED"
+        let modifier = BlockModifier {
+            $0.httpMethod = httpMethod
+        }
+        let client = ApiClient(baseUrl: url, modifiers: [modifier])
+        let request = Request()
+        var urlRequest = try await request.toUrlRequest(baseUrl: url)
+        try await client.modify(request: &urlRequest, extraModifiers: [], ignoreDefaultModifiers: false)
+        XCTAssertEqual(urlRequest.httpMethod, httpMethod)
+    }
+
+    @MainActor
+    func test_modify_doesnt_apply_default_modifiers_when_ignoreDefaultModifiers_true() async throws {
+        let expectedHttpMethod = "EXPECTED"
+        let modifier = BlockModifier {
+            $0.httpMethod = "NOT_EXPECTED"
+        }
+        let client = ApiClient(baseUrl: url, modifiers: [modifier])
+        let request = Request()
+        var urlRequest = try await request.toUrlRequest(baseUrl: url)
+        urlRequest.httpMethod = expectedHttpMethod
+        try await client.modify(request: &urlRequest, extraModifiers: [], ignoreDefaultModifiers: true)
+        XCTAssertEqual(urlRequest.httpMethod, expectedHttpMethod)
+    }
+
+    @MainActor
+    func test_modify_applies_extra_modifiers_when_ignoreDefaultModifiers_false() async throws {
+        let httpMethod = "EXPECTED"
+        let modifier = BlockModifier {
+            $0.httpMethod = httpMethod
+        }
+        let client = ApiClient(baseUrl: url)
+        let request = Request()
+        var urlRequest = try await request.toUrlRequest(baseUrl: url)
+        try await client.modify(request: &urlRequest, extraModifiers: [modifier], ignoreDefaultModifiers: false)
+        XCTAssertEqual(urlRequest.httpMethod, httpMethod)
+    }
+
+    @MainActor
+    func test_modify_applies_extra_modifiers_when_ignoreDefaultModifiers_true() async throws {
+        let httpMethod = "EXPECTED"
+        let modifier = BlockModifier {
+            $0.httpMethod = httpMethod
+        }
+        let client = ApiClient(baseUrl: url)
+        let request = Request()
+        var urlRequest = try await request.toUrlRequest(baseUrl: url)
+        try await client.modify(request: &urlRequest, extraModifiers: [modifier], ignoreDefaultModifiers: true)
+        XCTAssertEqual(urlRequest.httpMethod, httpMethod)
+    }
+
+    struct TestError: Error, Equatable {}
+
+    @MainActor
+    func test_modify_wraps_default_modifier_error() async throws {
+        let modifier = BlockModifier { _ in
+            throw TestError()
+        }
+        let client = ApiClient(baseUrl: url, modifiers: [modifier])
+        let request = Request()
+        var urlRequest = try await request.toUrlRequest(baseUrl: url)
+        do {
+            try await client.modify(request: &urlRequest, extraModifiers: [], ignoreDefaultModifiers: false)
+            XCTFail("Expected modify to throw")
+        } catch {
+            let requestError = try XCTUnwrap(error as? RequestError, "Thrown error should be a RequestError")
+            if case .requestModifierError(let wrapped) = requestError.error {
+                _ = try XCTUnwrap(wrapped as? TestError, "Expected error to be equal to the one thrown by the modifier")
+            } else {
+                XCTFail("Expected wrapped error to be case requestModifierError")
+            }
+        }
+    }
+
+    @MainActor
+    func test_modify_wraps_extra_modifier_error() async throws {
+        let modifier = BlockModifier { _ in
+            throw TestError()
+        }
+        let client = ApiClient(baseUrl: url)
+        let request = Request()
+        var urlRequest = try await request.toUrlRequest(baseUrl: url)
+        do {
+            try await client.modify(request: &urlRequest, extraModifiers: [modifier], ignoreDefaultModifiers: false)
+            XCTFail("Expected modify to throw")
+        } catch {
+            let requestError = try XCTUnwrap(error as? RequestError, "Thrown error should be a RequestError")
+            if case .requestModifierError(let wrapped) = requestError.error {
+                _ = try XCTUnwrap(wrapped as? TestError, "Expected error to be equal to the one thrown by the modifier")
+            } else {
+                XCTFail("Expected wrapped error to be case requestModifierError")
+            }
+        }
     }
 }


### PR DESCRIPTION
- implement UTs for `ApiClient` `modify()` and `validate()` functions
- change API to distinguish functions that return only parsed entity and those returning a couple `(ResponseBody, HTTPURLResponse)` in order to solve potential ambiguity in intermediary situations (affecting code completion)
- update and adapt README